### PR TITLE
ONE annotation is required for comments, no more!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.mkotb</groupId>
     <artifactId>config-api</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
 
     <name>ConfigAPI</name>
     <description>GSON-like ORM for the Bukkit Config API</description>

--- a/src/main/java/xyz/mkotb/configapi/comment/Comment.java
+++ b/src/main/java/xyz/mkotb/configapi/comment/Comment.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.TYPE})
 public @interface Comment {
-    String value();
+    String[] value();
 }

--- a/src/main/java/xyz/mkotb/configapi/comment/CommentHelper.java
+++ b/src/main/java/xyz/mkotb/configapi/comment/CommentHelper.java
@@ -63,7 +63,7 @@ public final class CommentHelper {
 
     public static String[] valueFrom(Annotation annotation) {
         if (annotation instanceof Comment) {
-            return new String[] {((Comment) annotation).value()};
+            return ((Comment) annotation).value();
         }
 
         if (annotation instanceof HeaderComment) {

--- a/src/main/java/xyz/mkotb/configapi/comment/Comments.java
+++ b/src/main/java/xyz/mkotb/configapi/comment/Comments.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
+@Deprecated
 public @interface Comments {
     String[] value();
 }

--- a/src/main/java/xyz/mkotb/configapi/comment/HeaderComment.java
+++ b/src/main/java/xyz/mkotb/configapi/comment/HeaderComment.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface HeaderComment {
     String value();
 }

--- a/src/main/java/xyz/mkotb/configapi/comment/HeaderComments.java
+++ b/src/main/java/xyz/mkotb/configapi/comment/HeaderComments.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface HeaderComments {
     String[] value();
 }


### PR DESCRIPTION
The `@Comment` annotation should be used for all types of comments, seeing as annotations are extremely flexible in the way they allow you to input values.

`String[] value()` can accept `"value"` or `{"value1", "value2"}`

also, `@Target` can, using the same technique, accept multiple types of targets, allowing you to use the `@Comment` for both header and field comments, single line or not.

Support is maintained for the other annotations, however. The signature change applied to the `@Comment` method `value()` (return type `String` -> `String[]`) does not change the syntax required, and as such projects that use this version will not have to make any changes to their code.

The version is also bumped to `1.0.1` due to the change in signature of the annotation `@Comment`
