### PR TITLE
Allow arbitrary files

### DIFF
--- a/src/main/java/xyz/mkotb/configapi/ConfigFactory.java
+++ b/src/main/java/xyz/mkotb/configapi/ConfigFactory.java
@@ -54,8 +54,12 @@ public final class ConfigFactory {
     }
 
     public <T> T fromFile(String name, Class<T> classOf) {
-        File config = new File(configDirectory(), name + ".yml");
+        return fromFile(new File(configDirectory(), name + ".yml"), classOf);
+    }
 
+    public <T> T fromFile(File config, Class<T> classOf) {
+        String rawName = config.getName();
+        String name = rawName.substring(0, rawName.lastIndexOf('.') + 1);
         if (!config.exists()) {
             CentralDummyHolder dummyHolder = CentralDummyHolder.instance();
             T dummy;


### PR DESCRIPTION
Another addition in 1.0.1, you can now hand the ConfigFactory a "File" instance directly, and it will be able to load that as well.

Added:
`ConfigFactory#<T>fromFile(java.io.File, java.lang.Class<T>`

Refactored:
`ConfigFactory#<T>fromFile(java.lang.String, java.lang.Class<T>`

Non breaking change.
